### PR TITLE
Remove comments to fix configure.js

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,11 +1,7 @@
 // $Id$
 // vim:ft=javascript
 
-// If your extension references something external, use ARG_WITH
-// ARG_WITH("xxhash", "for xxhash support", "no");
-
-// Otherwise, use ARG_ENABLE
-// ARG_ENABLE("xxhash", "enable xxhash support", "no");
+ARG_ENABLE("xxhash", "enable xxhash support", "no");
 
 if (PHP_XXHASH != "no") {
 	EXTENSION("xxhash", "php_xxhash.c");


### PR DESCRIPTION
Comments prevent buildconf from correctly generating configure.js.